### PR TITLE
add basic notes to test locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ with special focus on using various NASA related datasets.
 
 To build, run and test the image locally:
 
-Checkout this repository, and in the code folder:
+Checkout this repository, and after `cd`ing into the repository's directory:
 
     docker build -t qgis .
     docker run -it -p 8888:8888 --security-opt seccomp=unconfined qgis

--- a/README.md
+++ b/README.md
@@ -2,3 +2,25 @@
 
 An image for running QGIS in a Linux Desktop in the cloud,
 with special focus on using various NASA related datasets.
+
+# Test Locally
+
+To build, run and test the image locally:
+
+Checkout this repository, and in the code folder:
+
+```
+    docker build -t qgis .
+```
+
+```
+    docker run -it -p 8888:8888 --security-opt seccomp=unconfined qgis
+```
+
+This should start the docker container and emit logs which give you a URL you can open in your browser, that looks something like:
+
+   ```
+        http://127.0.0.1:8888/lab?token=<token>
+   ```
+
+Paste this into your browser. You should see a Jupyter Lab interface. Click on the Desktop button to open the desktop with QGIS installed.

--- a/README.md
+++ b/README.md
@@ -9,18 +9,11 @@ To build, run and test the image locally:
 
 Checkout this repository, and in the code folder:
 
-```
     docker build -t qgis .
-```
-
-```
     docker run -it -p 8888:8888 --security-opt seccomp=unconfined qgis
-```
 
 This should start the docker container and emit logs which give you a URL you can open in your browser, that looks something like:
 
-   ```
-        http://127.0.0.1:8888/lab?token=<token>
-   ```
+    http://127.0.0.1:8888/lab?token=<token>
 
 Paste this into your browser. You should see a Jupyter Lab interface. Click on the Desktop button to open the desktop with QGIS installed.


### PR DESCRIPTION
Added some notes on testing locally, taking from @yuvipanda's comment [here](https://github.com/2i2c-org/infrastructure/issues/3479#issuecomment-1843270055).

Tested locally and it worked smooth!

We can add docs on pushing the docker image and testing on a Hub instance when we get to it - just wanted something basic in the README for now for folks working on it to get setup.