### PR TITLE
start QGIS automatically on opening desktop

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,5 @@ COPY --chown=1000:1000 setup-qgis-plugins.bash /tmp/setup-qgis-plugins.bash
 RUN /tmp/setup-qgis-plugins.bash && rm /tmp/setup-qgis-plugins.bash
 
 COPY qgis.desktop ${DESKTOP_FILES_DIR}/qgis.desktop
+COPY qgis.desktop /etc/xdg/autostart/qgis.desktop
 COPY qgis.xml ${MIME_FILES_DIR}/qgis.xml

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,5 +31,9 @@ COPY --chown=1000:1000 setup-qgis-plugins.bash /tmp/setup-qgis-plugins.bash
 RUN /tmp/setup-qgis-plugins.bash && rm /tmp/setup-qgis-plugins.bash
 
 COPY qgis.desktop ${DESKTOP_FILES_DIR}/qgis.desktop
+
+# Copy files to autostart folder, so that QGIS auto-starts when opening the Desktop
+# See: https://manpages.ubuntu.com/manpages/focal/en/man1/xdg-autostart.1.html
 COPY qgis.desktop /etc/xdg/autostart/qgis.desktop
+
 COPY qgis.xml ${MIME_FILES_DIR}/qgis.xml


### PR DESCRIPTION
Ref https://github.com/2i2c-org/nasa-qgis-image/issues/3

Seems like putting the `.desktop` files into the `/etc/xdg/autostart/` folder makes it so that that application is launched automatically on startup.

This seems to work. Only issue is that the window did not open full-screen - so for me it opened about quarter screen and I had to then maximize it. Can look into if one can force it to open full-screen.

Currently I just added a line to also copy the `.desktop` file to /etc/xdg/autostart/ but @yuvipanda if this works maybe I can just change the `DESKTOP_FILES_DIR` to be `/etc/xdg/autostart/` instead of `/opt/desktop-files/` - not sure if we should have it in both places.

cc @yuvipanda @geohacker