### PR TITLE
Use newer version of jupyter-remote-desktop-proxy

### DIFF
--- a/setup-scripts/setup-linux-desktop.bash
+++ b/setup-scripts/setup-linux-desktop.bash
@@ -44,7 +44,8 @@ mamba install -c conda-forge --yes \
       jupyter-server-proxy \
       nbgitpuller
 
-python -m pip install --no-cache "jupyter-remote-desktop-proxy==1.2.1"
+# Until https://github.com/jupyterhub/jupyter-remote-desktop-proxy/issues/87 is sorted
+python -m pip install --no-cache git+https://github.com/jupyterhub/jupyter-remote-desktop-proxy@a7c1ae9bca94ca3a4bbf90f7a105e16b1603d4bd
 
 fix-permissions "${CONDA_DIR}"
 fix-permissions "/home/${NB_USER}"


### PR DESCRIPTION
There's a lot of helpful UI changes to the desktop that haven't been released yet (primarily https://github.com/jupyterhub/jupyter-remote-desktop-proxy/pull/78). In particular, the hub control panel is much easier to access, and so is the clipboard.

Until a release is made (https://github.com/jupyterhub/jupyter-remote-desktop-proxy/issues/87), we can install it directly from source